### PR TITLE
adding -i for response details dumping (include headers...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Relevant flags (some extra are from fortio library but not used/relevant)
 
 ```
 flags:
-  -4	Only IPv4
-  -6	Only IPv6
+flags:
+  -4	Use only IPv4
+  -6	Use only IPv6
+  -i	Include response headers in output
   -s	Quiet mode (sets log level to warning quietly)
   -loglevel value
     	loglevel, one of [Debug Verbose Info Warning Error Critical Fatal] (default Info)

--- a/cli/main.go
+++ b/cli/main.go
@@ -47,8 +47,9 @@ func usage(msg string, args ...any) {
 // Note that we could use the (new in 1.39) log.Fatalf that doesn't panic for cli tools but
 // it calling os.Exit directly means it doesn't work with the code coverage from `testscript`.
 func Main() int {
-	ipv4 := flag.Bool("4", false, "Only IPv4")
-	ipv6 := flag.Bool("6", false, "Only IPv6")
+	ipv4 := flag.Bool("4", false, "Use only IPv4")
+	ipv6 := flag.Bool("6", false, "Use only IPv6")
+	inclHeaders := flag.Bool("i", false, "Include response headers in output")
 	method := flag.String("method", http.MethodGet, "HTTP method")
 	totalTimeout := flag.Duration("total-timeout", 30*time.Second, "HTTP method")
 	requestTimeout := flag.Duration("request-timeout", 3*time.Second, "HTTP method")
@@ -84,5 +85,11 @@ func Main() int {
 	log.Infof("Fortio multicurl %s, using resolver %s, %s %s", longV, resolveType, *method, url)
 	ctx, cncl := context.WithTimeout(context.Background(), *totalTimeout)
 	defer cncl()
-	return mc.MultiCurl(ctx, *requestTimeout, *method, url, resolveType)
+	return mc.MultiCurl(ctx, &mc.Config{
+		RequestTimeout: *requestTimeout,
+		Method:         *method,
+		URL:            url,
+		ResolveType:    resolveType,
+		IncludeHeaders: *inclHeaders,
+	})
 }

--- a/cli/multicurl.txtar
+++ b/cli/multicurl.txtar
@@ -62,3 +62,8 @@ stderr 'E Unable to resolve port "90000": address 90000: invalid port'
 multicurl -4 -s http://demo.fortio.org/x
 ! stderr 'I Resolving'
 stderr 'W Total 0 errors \(2 warnings\)'
+
+# -i mode (assumes demo.fortio.org is fronted by cloudflare)
+multicurl -4 -i http://demo.fortio.org/x
+stdout 'HTTP/1.1 303 See Other'
+stdout 'Server: cloudflare'


### PR DESCRIPTION
fixes #8

also introduce a mc.Config object
