### PR TITLE
more usable api/library - option to repeat until success

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # multicurl
 
-Fetches a URL from all the IPs of a given host
+Fetches a URL from all the IPs of a given host. Optionally repeat until an expected result code is obtained from all addresses.
 
 ## Installation
 ```shell
@@ -26,6 +26,7 @@ Relevant flags (some extra are from fortio library but not used/relevant)
 
 ```
 flags:
+flags:
   -4	Use only IPv4
   -6	Use only IPv6
   -H key:value
@@ -36,19 +37,24 @@ flags:
     	HTTP method to use, default is GET unless -d is set which defaults to POST
   -d string
     	Payload to POST, use @filename to read from file
+  -expected int
+    	Expected HTTP return code, 0 means any and non 200s will be warning otherwise if set any different code is an error
   -i	Include response headers in output
-  -s	Quiet mode (sets log level to warning quietly)
-  -o file name pattern
-    	Output file name pattern, e.g "out-%.html" where % will be replaced by the ip, default is stdout
   -loglevel value
     	loglevel, one of [Debug Verbose Info Warning Error Critical Fatal] (default Info)
+  -o file name pattern
+    	Output file name pattern, e.g "out-%.html" where % will be replaced by the ip, default is stdout
+  -repeat int
+    	Max number of times to retry on errors if positive, default is 0 (no retry), negative is retry until -total-timeout
+  -repeat-delay duration
+    	Delay between retries (default 5s)
   -request-timeout duration
     	HTTP method (default 3s)
+  -s	Quiet mode (sets log level to warning quietly)
   -total-timeout duration
     	HTTP method (default 30s)
   -version
     	Show full version info and exit.
-
 ```
 
 See also [multicurl.txtar](multicurl.txtar) for examples (tests)

--- a/cli/main.go
+++ b/cli/main.go
@@ -124,7 +124,9 @@ func Main() int {
 		config.Method = http.MethodGet
 	}
 	log.Debugf("Config: %+v", config)
-	return mc.MultiCurl(ctx, config)
+	exitCode, results := mc.MultiCurl(ctx, config)
+	log.Infof("Detailed results: %+v", results)
+	return exitCode
 }
 
 func payload(dataStr string) []byte {

--- a/cli/multicurl.txtar
+++ b/cli/multicurl.txtar
@@ -138,6 +138,11 @@ stdin ips.txt
 multicurl -4 -I - https://debug.fortio.org
 stderr 'Using stdin for list of IPs to connect to'
 
+# retries
+! multicurl -4 -repeat -1 -repeat-delay 1s -total-timeout 2.5s -expected 301 http://debug.fortio.org
+stderr 'E Interrupted/total timeout reached'
+stderr 'I Total iterations: 2,'
+
 -- payloadFile.txt --
 Just a test
 of payload

--- a/cli/multicurl.txtar
+++ b/cli/multicurl.txtar
@@ -52,7 +52,7 @@ stderr 'E Unable to lookup "doesntexist.fortio.org": lookup doesntexist.fortio.o
 
 # redirect
 multicurl -4 http://demo.fortio.org/x
-stderr 'Total 0 errors \(2 warnings\)'
+stderr '\[1\] 0 errors \(2 warnings\)'
 stderr 'Status 303 '
 
 # bad port
@@ -62,7 +62,7 @@ stderr 'F Unable to resolve port "90000": address 90000: invalid port'
 # -s mode
 multicurl -4 -s http://demo.fortio.org/x
 ! stderr 'I Resolving'
-stderr 'W Total 0 errors \(2 warnings\)'
+stderr 'W \[1\] 0 errors \(2 warnings\)'
 
 # -i mode (assumes demo.fortio.org is fronted by cloudflare)
 multicurl -4 -i http://demo.fortio.org/x


### PR DESCRIPTION
Example of max repeat reached without success: (status=503:50 means return 50% of 503s)
```
$ go run . -expected 200 -repeat 1 -repeat-delay 1s localhost:8080/?status=503:50
18:28:42 I Fortio multicurl dev  go1.19.5 arm64 darwin, using resolver ip, GET localhost:8080/?status=503:50
18:28:42 I Resolved ip localhost:8080 to port 8080 and 2 addresses [::1 127.0.0.1]
18:28:42 I 1: Status 200 "200 OK" from ::1
18:28:42 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:28:42 E [1] 1 error (0 warnings)
18:28:43 E 1: Status 503 "503 Service Unavailable" from ::1
18:28:43 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:28:43 E [2] 2 errors (0 warnings)
18:28:43 E Reached max repeat 1
18:28:43 I Total iterations: 2, errors: 3, warnings 0
exit status 2
```

With eventual success
```
$ go run . -expected 200 -repeat -1 -repeat-delay 1s localhost:8080/?status=503:50
18:30:40 I Fortio multicurl dev  go1.19.5 arm64 darwin, using resolver ip, GET localhost:8080/?status=503:50
18:30:40 I Resolved ip localhost:8080 to port 8080 and 2 addresses [::1 127.0.0.1]
18:30:40 I 1: Status 200 "200 OK" from ::1
18:30:40 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:30:40 E [1] 1 error (0 warnings)
18:30:41 E 1: Status 503 "503 Service Unavailable" from ::1
18:30:41 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:30:41 E [2] 2 errors (0 warnings)
18:30:42 E 1: Status 503 "503 Service Unavailable" from ::1
18:30:42 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:30:42 E [3] 2 errors (0 warnings)
18:30:43 I 1: Status 200 "200 OK" from ::1
18:30:43 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:30:43 E [4] 1 error (0 warnings)
18:30:44 E 1: Status 503 "503 Service Unavailable" from ::1
18:30:44 I 2: Status 200 "200 OK" from 127.0.0.1
18:30:44 E [5] 1 error (0 warnings)
18:30:45 I 1: Status 200 "200 OK" from ::1
18:30:45 I 2: Status 200 "200 OK" from 127.0.0.1
18:30:45 E [6] 0 errors (0 warnings)
18:30:45 I Total iterations: 6, errors: 7, warnings 0
```

With timeout before success
```
$ go run . -expected 200 -repeat -1 -repeat-delay 1s -total-timeout 5s localhost:8080/?status=503
18:31:27 I Fortio multicurl dev  go1.19.5 arm64 darwin, using resolver ip, GET localhost:8080/?status=503
18:31:27 I Resolved ip localhost:8080 to port 8080 and 2 addresses [::1 127.0.0.1]
18:31:27 E 1: Status 503 "503 Service Unavailable" from ::1
18:31:27 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:31:27 E [1] 2 errors (0 warnings)
18:31:28 E 1: Status 503 "503 Service Unavailable" from ::1
18:31:28 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:31:28 E [2] 2 errors (0 warnings)
18:31:29 E 1: Status 503 "503 Service Unavailable" from ::1
18:31:29 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:31:29 E [3] 2 errors (0 warnings)
18:31:30 E 1: Status 503 "503 Service Unavailable" from ::1
18:31:30 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:31:30 E [4] 2 errors (0 warnings)
18:31:31 E 1: Status 503 "503 Service Unavailable" from ::1
18:31:31 E 2: Status 503 "503 Service Unavailable" from 127.0.0.1
18:31:31 E [5] 2 errors (0 warnings)
18:31:32 E Interrupted/total timeout reached
18:31:32 I Total iterations: 5, errors: 10, warnings 0
exit status 2
```
