### PR TITLE
stay on go 1.19.* for now

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-go@v3
       with:
-          go-version: 'stable'
+          go-version: '1.19'
     - name: Run test coverage
       run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
     - uses: codecov/codecov-action@v3

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3 # pin@v3
         with:
-          go-version: 'stable'
+          go-version: '1.19'
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin@v2
         with:


### PR DESCRIPTION
stay on 1.19 pending https://github.com/actions/setup-go/issues/327