### PR TITLE
mtls (client cert) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ flags:
         IP address file to use instead of resolving the URL, use - for stdin
   -X string
         HTTP method to use, default is GET unless -d is set which defaults to POST
-  -cacert Path
+  -cacert file
         Path to a custom CA certificate file to use instead of system ones.
+  -cert file
+        Path to a custom client certificate file for mTLS.
   -cert-expiry days
         Certificate expiry error threshold in days (default 7)
   -d string
@@ -56,6 +58,8 @@ set any different code is an error
   -i    Include response headers in output
   -insecure
         Skip verification of server certificate (insecure TLS)
+  -key file
+        Path to a custom client key file for mTLS.
   -loglevel level
         log level, one of [Debug Verbose Info Warning Error Critical Fatal] (default Info)
   -n int
@@ -201,7 +205,7 @@ body:
 exit status 2
 ```
 
-#### Certificate informations
+#### Certificate information
 
 ```bash
 % multicurl -4 -cert-expiry 60 https://debug.fortio.org > /dev/null

--- a/cli/main.go
+++ b/cli/main.go
@@ -67,8 +67,10 @@ func Main() int {
 	relookup := flag.Bool("relookup", false, "Re-lookup the URL between each repeat")
 	expiryThreshold := flag.Float64("cert-expiry", 7, "Certificate expiry error threshold in `days`")
 	caCertFlag := flag.String("cacert", "",
-		"`Path` to a custom CA certificate file to use instead of system ones.")
+		"Path to a custom CA certificate `file` to use instead of system ones.")
 	insecure := flag.Bool("insecure", false, "Skip verification of server certificate (insecure TLS)")
+	certFlag := flag.String("cert", "", "Path to a custom client certificate `file` for mTLS.")
+	keyFlag := flag.String("key", "", "Path to a custom client key `file` for mTLS.")
 
 	cli.ProgramName = "Fortio multicurl"
 	cli.ArgsHelp = "url"
@@ -101,6 +103,8 @@ func Main() int {
 	config.CertExpiryError = mc.Dur(*expiryThreshold)
 	config.Insecure = *insecure
 	config.CAFile = *caCertFlag
+	config.Cert = *certFlag
+	config.Key = *keyFlag
 	if *data != "" {
 		if config.Method == "" {
 			config.Method = http.MethodPost

--- a/cli/multicurl.txtar
+++ b/cli/multicurl.txtar
@@ -184,10 +184,12 @@ stderr 'I Certificate "CN=..badssl.com'
 stderr 'F LoadX509KeyPair error for cert nosuchfile.crt / key nosuchfile.key: open nosuchfile.crt: no such file or directory'
 
 # mtls test
-exec curl -s -o client.p12 https://badssl.com/certs/badssl.com-client.p12
+# on mac you need to use openssl from
+# brew install openssl@3
+exec curl -sS -o client.p12 https://badssl.com/certs/badssl.com-client.p12
 exec openssl version
-exec openssl pkcs12 -in client.p12 -out client.crt -clcerts -nokeys -passin pass:badssl.com
-exec openssl pkcs12 -in client.p12 -out client.key -nocerts -nodes -passin pass:badssl.com
+exec openssl pkcs12 -legacy -in client.p12 -out client.crt -clcerts -nokeys -passin pass:badssl.com
+exec openssl pkcs12 -legacy -in client.p12 -out client.key -nocerts -nodes -passin pass:badssl.com
 multicurl -4 -cert client.crt -key client.key https://client.badssl.com/
 stdout 'This site requires a .*client-authenticated.*TLS handshake'
 

--- a/cli/multicurl.txtar
+++ b/cli/multicurl.txtar
@@ -185,6 +185,7 @@ stderr 'F LoadX509KeyPair error for cert nosuchfile.crt / key nosuchfile.key: op
 
 # mtls test
 exec curl -s -o client.p12 https://badssl.com/certs/badssl.com-client.p12
+exec openssl version
 exec openssl pkcs12 -in client.p12 -out client.crt -clcerts -nokeys -passin pass:badssl.com
 exec openssl pkcs12 -in client.p12 -out client.key -nocerts -nodes -passin pass:badssl.com
 multicurl -4 -cert client.crt -key client.key https://client.badssl.com/

--- a/cli/multicurl.txtar
+++ b/cli/multicurl.txtar
@@ -183,6 +183,13 @@ stderr 'I Certificate "CN=..badssl.com'
 ! multicurl -4 -cert nosuchfile.crt -key nosuchfile.key https://debug.fortio.org/
 stderr 'F LoadX509KeyPair error for cert nosuchfile.crt / key nosuchfile.key: open nosuchfile.crt: no such file or directory'
 
+# mtls test
+exec curl -s -o client.p12 https://badssl.com/certs/badssl.com-client.p12
+exec openssl pkcs12 -in client.p12 -out client.crt -clcerts -nokeys -passin pass:badssl.com
+exec openssl pkcs12 -in client.p12 -out client.key -nocerts -nodes -passin pass:badssl.com
+multicurl -4 -cert client.crt -key client.key https://client.badssl.com/
+stdout 'This site requires a .*client-authenticated.*TLS handshake'
+
 -- payloadFile.txt --
 Just a test
 of payload

--- a/cli/multicurl.txtar
+++ b/cli/multicurl.txtar
@@ -179,6 +179,9 @@ exec sh -c 'openssl s_client -showcerts -servername self-signed.badssl.com -conn
 multicurl -4 -cacert test.ca https://self-signed.badssl.com/
 stderr 'I Certificate "CN=..badssl.com'
 
+# bad client cert path
+! multicurl -4 -cert nosuchfile.crt -key nosuchfile.key https://debug.fortio.org/
+stderr 'F LoadX509KeyPair error for cert nosuchfile.crt / key nosuchfile.key: open nosuchfile.crt: no such file or directory'
 
 -- payloadFile.txt --
 Just a test


### PR DESCRIPTION
Tested manually against fortio server

```
% go run . -cacert ~/github/fortio.org/fortio/cert-tmp/ca.crt -key ~/github/fortio.org/fortio/cert-tmp/client.key -cert  ~/github/fortio.org/fortio/cert-tmp/client.crt https://localhost:8080/debug > /dev/null 
15:16:27 I Fortio multicurl dev  go1.19.6 arm64 darwin, using resolver ip, GET https://localhost:8080/debug
15:16:27 I Resolved ip localhost:8080 to port 8080 and 2 addresses [::1 127.0.0.1]
15:16:27 I 1: Status 200 "200 OK" from ::1
15:16:27 I Certificate "CN=fake-server" expires in 357 days
15:16:27 I 2: Status 200 "200 OK" from 127.0.0.1
15:16:27 I Certificate "CN=fake-server" expires in 357 days
15:16:27 I [1] 0 errors (0 warnings)
15:16:27 I Shortest cert expiry is 2024-02-25 18:52:52 +0000 UTC (356.8 days from now)
15:16:27 I Total iterations: 1, errors: 0, warnings 0
dl@MacBook-Air multicurl % go run . -cacert ~/github/fortio.org/fortio/cert-tmp/ca.crt -key ~/github/fortio.org/fortio/cert-tmp/client.key -cert  ~/github/fortio.org/fortio/cert-tmp/client.crt https://localhost:8080/debug           
15:16:36 I Fortio multicurl dev  go1.19.6 arm64 darwin, using resolver ip, GET https://localhost:8080/debug
15:16:36 I Resolved ip localhost:8080 to port 8080 and 2 addresses [::1 127.0.0.1]
15:16:36 I 1: Status 200 "200 OK" from ::1
15:16:36 I Certificate "CN=fake-server" expires in 357 days
Φορτίο version dev  go1.19.6 arm64 darwin echo debug server up for 53m42.1s on MacBook-Air.local - request from [::1]:50287 https TLS_AES_128_GCM_SHA256 "CN=fake-client"

GET /debug HTTP/2.0

headers:

Host: localhost:8080
Accept-Encoding: gzip
User-Agent: fortio.org/multicurl-dev

body:


15:16:36 I 2: Status 200 "200 OK" from 127.0.0.1
15:16:36 I Certificate "CN=fake-server" expires in 357 days
Φορτίο version dev  go1.19.6 arm64 darwin echo debug server up for 53m42.1s on MacBook-Air.local - request from 127.0.0.1:50288 https TLS_AES_128_GCM_SHA256 "CN=fake-client"

GET /debug HTTP/2.0

headers:

Host: localhost:8080
Accept-Encoding: gzip
User-Agent: fortio.org/multicurl-dev

body:


15:16:36 I [1] 0 errors (0 warnings)
15:16:36 I Shortest cert expiry is 2024-02-25 18:52:52 +0000 UTC (356.8 days from now)
15:16:36 I Total iterations: 1, errors: 0, warnings 0
```

Also now automated using https://badssl.com/ certs

