### PR TITLE
change/document the behavior of -H Host:xxx to also make xxx be the TLS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ negative is retry until -total-timeout
 
 Note that `-relookup` works better on CGO_ENABLED=0 built binary, otherwise the OS library caches the results.
 
+Note that `-H Host:xxx https://yyyy/` is a special header and using that will be the same as querying `https://xxx/` using the IPs of `yyy` (convenient to test a virtual host against a LoadBalancer or ingress name before the DNS is updated)
+
 See also [multicurl.txtar](multicurl.txtar) for examples (tests)
 
 ### Example

--- a/cli/multicurl.txtar
+++ b/cli/multicurl.txtar
@@ -94,6 +94,14 @@ stdout 'POST / HTTP/1.1'
 stdout -count=2 'foo bar'
 stderr 'V Will be setting special Host header to debug.fortio.org'
 
+# Host header for https
+# get the debug cert despite using the demo.oracle.fortio.org IPs
+multicurl -4 -loglevel verbose -H Host:debug.fortio.org -d 'foo bar' https://demo.oracle.fortio.org
+stdout 'Debug server on'
+stdout 'Request from .* https TLS_'
+stderr 'V Will be setting special Host header to debug.fortio.org'
+stderr 'I Certificate "CN=debug.fortio.org" expires in'
+
 # bad -H
 ! multicurl -H foo debug.fortio.org
 stderr 'invalid value "foo" for flag -H: invalid extra header .foo., expecting Key: Value'

--- a/mc/mc.go
+++ b/mc/mc.go
@@ -55,7 +55,9 @@ type Config struct {
 	IncludeHeaders bool
 	// Headers are the headers to use for the request. Must be initialized. Or call NewConfig().
 	Headers http.Header
-	// HostOverride is the host/authority to use for the request. If empty, the host from the URL is used
+	// HostOverride is the host/authority to use for the request. If empty, the host from the URL is used.
+	// This will also change the ServerName used for TLS handshake (sni) so in essence passing HostOverride
+	// is the same as passing the IPs of the server of the url and using the name from HostOverride as the url.
 	HostOverride string
 	// OutputPattern is the pattern to use for the output file names, must contain a % which will get replaced by
 	// the IP of the target. If empty or "-", output is written to stdout. If "none" no output is written.
@@ -179,6 +181,7 @@ func MultiCurl(ctx context.Context, cfg *Config) (int, ResultStats) { //nolint:f
 		InsecureSkipVerify: cfg.Insecure, //nolint:gosec // on purpose with the flag/config
 		RootCAs:            ca,
 		Certificates:       certs,
+		ServerName:         cfg.HostOverride,
 	}
 	hcli := http.Client{
 		Transport: tr,


### PR DESCRIPTION
change/document the behavior of -H Host:xxx to also make xxx be the TLS servername in SNI/TLS handshake

such as
```
multicurl -H host:xxx https://yyy/a/b
```
is the same as
```
multicurl -I ips_of_yyy.txt https://xxx/a/b
```

(like simpler version of
```
host yyy | awk '{print $4}' | multicurl -I - https://xxx/a/b
```
this was already working for http but not https
)